### PR TITLE
Add Appveyor Deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image:
 - Ubuntu
 - Visual Studio 2015
 
-- skip_non_tags: true
+skip_non_tags: true
 
 build_script:
 - cmd: appveyor\build.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,9 @@ image:
 - Ubuntu
 - Visual Studio 2015
 
-build_script:
+- skip_non_tags: true
 
+build_script:
 - cmd: appveyor\build.bat
 - sh: chmod +x appveyor/build.sh && ./appveyor/build.sh
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: '#{build}'
+
+image:
+- Ubuntu
+- Visual Studio 2015
+
+build_script:
+
+- cmd: appveyor\build.bat
+- sh: chmod +x appveyor/build.sh && ./appveyor/build.sh
+
+artifacts:
+- path: ESMB-*64*
+
+deploy:
+- provider: GitHub
+  auth_token:
+    secure: +t67fTQF/OlAb0OEH0mntAmbF4MOWhR7Be+egNMeMSk8nchh6r9CTjzLUlWND9JZ

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,0 +1,17 @@
+REM Setup
+C:\Python37-x64\python -m pip install nuitka pyinstaller
+
+REM Nuitka Compilation
+C:\Python37-x64\python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --plugin-enable=tk-inter ESMB.py
+mv ESMB.dist ESMB
+7z a -tzip -mx9 -y ESMB-win64-nuitka.zip .\ESMB\
+rd /S /Q ESMB
+
+REM PyInstaller
+C:\Python37-x64\Scripts\pyinstaller -D -y -w ESMB.py
+7z a -tzip -mx9 -y ESMB-win64-pyinstaller.zip .\dist\ESMB
+rd /S /Q dist
+
+C:\Python37-x64\Scripts\pyinstaller -F -y -w ESMB.py
+cp dist\ESMB ESMB-win64-pyinstaller.exe
+rd /S /Q dist

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,0 +1,18 @@
+# Setup
+sudo apt-get update && sudo apt-get -y install python3-pip python3-tk
+pip3 install nuitka pyinstaller
+
+# Nuitka Compilation
+python3 -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons ESMB.py
+mv ESMB.dist ESMB
+tar -czvf ESMB-ubuntu-amd64-nuitka.tar.gz ESMB/
+rm -rf ESMB
+
+# PyInstaller
+pyinstaller -D -y -w ESMB.py
+tar -czvf ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
+rm -rf dist
+
+pyinstaller -F -y -w ESMB.py
+cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
+rm -rf dist


### PR DESCRIPTION
attempt no. 3, ref #4 #5 

This PR adds an appveyor configuration, which will build & publish binaries whenever a new release is created. It could also eventually be leveraged for test runs or linting.

If you want to try it, head over to my fork (`appveyor-test` branch) and push a new tag, 5 minutes later there should be usable binaries on the releases page.

After merging, some things need to be done to complete the setup:

- head over to appveyor.com and sign in using your github account.

- Create a new project, select this repository.

- create a new github token [here](https://github.com/settings/tokens/new) with the `public_repo` or `repo` permissions. 

- enter that token into https://ci.appveyor.com/tools/encrypt, then place the resulting value in appveyor.yml