### PR TITLE
Add basic theme support via ttkthemes

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -13,6 +13,7 @@ This handles the GUI for ESMB
 
 '''
 import tkinter.font as tkfont
+from ttkthemes import ThemedTk
 
 from menuactions import *
 from guiutils import *

--- a/GUI.py
+++ b/GUI.py
@@ -14,6 +14,7 @@ This handles the GUI for ESMB
 '''
 from tkinter import *
 from tkinter import ttk, StringVar
+from ttkthemes import ThemedTk
 
 from menuactions import *
 from guiutils import *
@@ -37,7 +38,7 @@ class GUI(object):
         #end if
 
         # Build the application window
-        self.gui = Tk()
+        self.gui = ThemedTk(theme="arc")
         self.gui.title("ESMissionBuilder")
         self.gui.configure(bg="orange")
 

--- a/PopupWindow.py
+++ b/PopupWindow.py
@@ -11,8 +11,7 @@
 
 '''
 
-from tkinter import Toplevel
-from tkinter.ttk import Button, Entry, Label
+from tkinter import Toplevel, ttk
 
 from guiutils import addMission
 
@@ -25,11 +24,11 @@ class PopupWindow(object):
         self.top.grab_set()             # freezes the app until the user enters or cancels
 
         # build the widgets
-        self.l = Label(self.top, text=text, background='white')
+        self.l = ttk.Label(self.top, text=text, background='white')
         self.l.pack()
-        self.e = Entry(self.top)
+        self.e = ttk.Entry(self.top)
         self.e.pack()
-        self.b = Button(self.top, text='Ok', command=self.cleanup)
+        self.b = ttk.Button(self.top, text='Ok', command=self.cleanup)
         self.b.pack()
     #end init
 

--- a/PopupWindow.py
+++ b/PopupWindow.py
@@ -11,7 +11,8 @@
 
 '''
 
-from tkinter import *
+from tkinter import Toplevel
+from tkinter.ttk import Button, Entry, Label
 
 from guiutils import addMission
 
@@ -24,7 +25,7 @@ class PopupWindow(object):
         self.top.grab_set()             # freezes the app until the user enters or cancels
 
         # build the widgets
-        self.l = Label(self.top, text=text, bg='white')
+        self.l = Label(self.top, text=text, background='white')
         self.l.pack()
         self.e = Entry(self.top)
         self.e.pack()

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,6 +1,5 @@
 REM Setup
-REM We need the development version of pyinstaller, because 3.4 does not include the hook for ttkthemes
-C:\Python37-x64\python -m pip install nuitka https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+C:\Python37-x64\python -m pip install nuitka PyInstaller
 C:\Python37-x64\python -m pip install -r requirements.txt
 
 REM Nuitka Compilation

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,17 +1,19 @@
 REM Setup
-C:\Python37-x64\python -m pip install nuitka pyinstaller
+REM We need the development version of pyinstaller, because 3.4 does not include the hook for ttkthemes
+C:\Python37-x64\python -m pip install nuitka https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+C:\Python37-x64\python -m pip install -r requirements.txt
 
 REM Nuitka Compilation
-C:\Python37-x64\python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --plugin-enable=tk-inter --windows-disable-console --windows-icon=icon.ico ESMB.py
+C:\Python37-x64\python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=appveyor/ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=icon.ico ESMB.py
 mv ESMB.dist ESMB
 7z a -tzip -mx9 -y ESMB-win64-nuitka.zip .\ESMB\
 rd /S /Q ESMB
 
 REM PyInstaller
-C:\Python37-x64\Scripts\pyinstaller -D -y -w -i icon.ico ESMB.py
+C:\Python37-x64\Scripts\pyinstaller -D -y -w -i icon.ico --hidden-import ttkthemes ESMB.py
 7z a -tzip -mx9 -y ESMB-win64-pyinstaller.zip .\dist\ESMB
 rd /S /Q dist
 
-C:\Python37-x64\Scripts\pyinstaller -F -y -w -i icon.ico ESMB.py
+C:\Python37-x64\Scripts\pyinstaller -F -y -w -i icon.ico --hidden-import ttkthemes ESMB.py
 cp dist\ESMB ESMB-win64-pyinstaller.exe
 rd /S /Q dist

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,18 +1,21 @@
 # Setup
-sudo apt-get update && sudo apt-get -y install python3-pip python3-tk
-pip3 install nuitka pyinstaller
+# chrpath can be required for nuitka's scons command, to adjust shared library paths
+sudo apt-get update && sudo apt-get -y install python3-pip python3-tk chrpath
+# We need the development version of pyinstaller, because 3.4 does not include the hook for ttkthemes
+pip3 install nuitka https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+pip3 install -r requirements.txt
 
 # Nuitka Compilation
-python3 -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons ESMB.py
+python3 -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=appveyor/ttkthemes_nuitka_plugin.py ESMB.py
 mv ESMB.dist ESMB
 tar -czvf ESMB-ubuntu-amd64-nuitka.tar.gz ESMB/
 rm -rf ESMB
 
 # PyInstaller
-pyinstaller -D -y -w ESMB.py
+pyinstaller -D -y -w --hidden-import ttkthemes ESMB.py
 tar -czvf ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
 rm -rf dist
 
-pyinstaller -F -y -w ESMB.py
+pyinstaller -F -y -w --hidden-import ttkthemes ESMB.py
 cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
 rm -rf dist

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,8 +1,7 @@
 # Setup
 # chrpath can be required for nuitka's scons command, to adjust shared library paths
 sudo apt-get update && sudo apt-get -y install python3-pip python3-tk chrpath
-# We need the development version of pyinstaller, because 3.4 does not include the hook for ttkthemes
-pip3 install nuitka https://github.com/pyinstaller/pyinstaller/archive/develop.tar.gz
+pip3 install nuitka PyInstaller
 pip3 install -r requirements.txt
 
 # Nuitka Compilation

--- a/appveyor/ttkthemes_nuitka_plugin.py
+++ b/appveyor/ttkthemes_nuitka_plugin.py
@@ -1,3 +1,17 @@
+''' ttkthemes_nuitka_plugin.py
+# Copyright (c) 2019 by MCOfficer
+#
+# Endless Sky Mission Builder is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later version.
+#
+# Endless Sky Mission Builder is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+This file contains a plug-in that fixes standalone nuitka builds with the ttkthemes module.
+'''
+
 import os
 from logging import info, warning
 from shutil import copytree

--- a/appveyor/ttkthemes_nuitka_plugin.py
+++ b/appveyor/ttkthemes_nuitka_plugin.py
@@ -1,0 +1,29 @@
+import os
+from logging import info, warning
+from shutil import copytree
+
+from nuitka.plugins.PluginBase import NuitkaPluginBase
+
+
+def get_ttkthemes_path():
+    import ttkthemes
+    return os.path.dirname(ttkthemes.__file__)
+
+
+class TtkthemesPlugin(NuitkaPluginBase):
+    """
+    This Plug-In copies the `ttkthemes` site-package to the output directory,
+    since ttkthemes expects its files to be there.
+    """
+
+    plugin_name = __file__
+    plugin_desc = "Required by ttkthemes packages"
+
+    def onStandaloneDistributionFinished(self, dist_dir):
+        source = get_ttkthemes_path()
+        dest = os.path.join(dist_dir, "ttkthemes")
+        if os.path.exists(dest):
+            warning("ttkthemes: %s already exists! Aborting" % dest)
+            return
+        info("ttkthemes: copying %s to %s" % (source, dest))
+        copytree(source, dest)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+ttkthemes


### PR DESCRIPTION
- Adds a `requirements.txt` file for pypi packages

- Changes the main `Tk` object to a `ThemedTk`, a drop-in replacement that supports themeing

- Changes `PopupWindow` to use `tkinter.ttk` widgets rather than their `tkinter` counterparts

- Uses `arc` as default theme, for a list of available themes see http://ttkthemes.readthedocs.io/en/latest/themes.html

- Changes the CI builds to work with ttkthemes (my test build [here](https://ci.appveyor.com/project/MCOfficer/endless-sky-mission-builder/builds/25619480) failed because i revoked appveyor's repo access so it cannot deploy, but the build itself went through)

- Changes the CI builds on linux to install the `chrpath` package, since nuitka occasionally needs it

---

Before / After on Windows 10 with dark theme:
![grafik](https://user-images.githubusercontent.com/22377202/60358367-2c7dbe00-99d6-11e9-876e-d52fa89392fc.png)

Before / After on Ubuntu Mate, default theme:
![grafik](https://user-images.githubusercontent.com/22377202/60358507-8b433780-99d6-11e9-8e6d-8a5fffd35367.png)
