### PR TITLE
Fix appveyor deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ image:
 skip_non_tags: true
 
 build_script:
-#- cmd: appveyor\build.bat
+- cmd: appveyor\build.bat
 - sh: chmod +x appveyor/build.sh && ./appveyor/build.sh
 
 artifacts:

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -6,31 +6,25 @@ REM Setup required Packages
 python -m pip install nuitka PyInstaller
 python -m pip install -r requirements.txt
 
-REM Switch to our source directory
-PUSHD .\src
-REM Now that we are in ".\src", paths relative to the top level have to be prefixed with "..\", e.g. "..\icon.ico"
-
 REM Nuitka Compilation
 REM The two plugin-related arguments are responsible for copying all required tkinter- and ttkthemes-files to the final distribution folder
-python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=..\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=..\icon.ico .\ESMB.py
+REM python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=.\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=.\icon.ico .\src\ESMB.py
 MOVE .\ESMB.dist .\ESMB
 REM Archive with maximum zip compression
-7z a -tzip -mx9 -y ..\ESMB-win64-nuitka.zip .\ESMB\
+7z a -tzip -mx9 -y .\ESMB-win64-nuitka.zip .\ESMB\
 REM Cleanup
 RD /S /Q ESMB
 
 REM Build a directory distribution ("-D") with PyInstaller
-pyinstaller -D --noconfirm --noconsole --icon ..\icon.ico --hidden-import ttkthemes .\ESMB.py
+REM We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
+pyinstaller -D --noconfirm --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
 REM Archive with maximum zip compression
-7z a -tzip -mx9 -y ..\ESMB-win64-pyinstaller.zip .\dist\ESMB
+7z a -tzip -mx9 -y .\ESMB-win64-pyinstaller.zip .\dist\ESMB
 REM Cleanup
 RD /S /Q dist
 
 REM Build a OneFile executable ("-F") with PyInstaller
-pyinstaller -F --noconfirm --noconsole --icon ..\icon.ico --hidden-import ttkthemes .\ESMB.py
-COPY .\dist\ESMB.exe ..\ESMB-win64-pyinstaller.exe
+pyinstaller -F --noconfirm --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
+COPY .\dist\ESMB.exe .\ESMB-win64-pyinstaller.exe
 REM Cleanup
 RD /S /Q dist
-
-REM Return to top level, just to be sure
-POPD

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -11,9 +11,8 @@ PUSHD .\src
 REM Now that we are in ".\src", paths relative to the top level have to be prefixed with "..\", e.g. "..\icon.ico"
 
 REM Nuitka Compilation
-REM We use "--mingw64" because i trust in it to be available more than clang, which would be the default
 REM The two plugin-related arguments are responsible for copying all required tkinter- and ttkthemes-files to the final distribution folder
-python -m nuitka --assume-yes-for-downloads --standalone --show-progress --mingw64 --show-scons --user-plugin=..\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=..\icon.ico .\ESMB.py
+python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=..\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=..\icon.ico .\ESMB.py
 MOVE .\ESMB.dist .\ESMB
 REM Archive with maximum zip compression
 7z a -tzip -mx9 -y ..\ESMB-win64-nuitka.zip .\ESMB\

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,5 +1,5 @@
 REM Add our desired Python installation the *beginning* of the PATH, so the "python" command refers to this executable.
-REM It HAS to be 3.7+, otherwise PyInstaller binaries will have import errors.
+REM It HAS to be 3.7+, otherwise PyInstaller binaries will have import errors for some reason.
 REM Also add its "Scripts" folder, which will contain the PyInstaller executable once installed.
 set PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -4,7 +4,7 @@ REM Also add its "Scripts" folder, which will contain the PyInstaller executable
 set PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
 REM Setup required Packages
-python -m pip install nuitka
+python -m pip install PyInstaller
 python -m pip install -r requirements.txt
 
 REM Build a directory distribution ("-D") with PyInstaller

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,20 +1,37 @@
-REM Setup
-C:\Python37-x64\python -m pip install nuitka PyInstaller
-C:\Python37-x64\python -m pip install -r requirements.txt
+REM Add our desired Python installation the *beginning* of the PATH, so the "python" command refers to this executable.
+REM Also add its "Scripts" folder, which will contain the PyInstaller executable once installed.
+set PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
-PUSHD ".\src"
+REM Setup required Packages
+python -m pip install nuitka PyInstaller
+python -m pip install -r requirements.txt
+
+REM Switch to our source directory
+PUSHD .\src
+REM Now that we are in ".\src", paths relative to the top level have to be prefixed with "..\", e.g. "..\icon.ico"
 
 REM Nuitka Compilation
-C:\Python37-x64\python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=appveyor/ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=icon.ico ESMB.py
-mv ESMB.dist ESMB
-7z a -tzip -mx9 -y ESMB-win64-nuitka.zip .\ESMB\
-rd /S /Q ESMB
+REM We use "--mingw64" because i trust in it to be available more than clang, which would be the default
+REM The two plugin-related arguments are responsible for copying all required tkinter- and ttkthemes-files to the final distribution folder
+python -m nuitka --assume-yes-for-downloads --standalone --show-progress --mingw64 --show-scons --user-plugin=..\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=..\icon.ico .\ESMB.py
+MOVE .\ESMB.dist .\ESMB
+REM Archive with maximum zip compression
+7z a -tzip -mx9 -y ..\ESMB-win64-nuitka.zip .\ESMB\
+REM Cleanup
+RD /S /Q ESMB
 
-REM PyInstaller
-C:\Python37-x64\Scripts\pyinstaller -D -y -w -i icon.ico --hidden-import ttkthemes ESMB.py
-7z a -tzip -mx9 -y ESMB-win64-pyinstaller.zip .\dist\ESMB
-rd /S /Q dist
+REM Build a directory distribution ("-D") with PyInstaller
+pyinstaller -D --noconfirm --noconsole --icon ..\icon.ico --hidden-import ttkthemes .\ESMB.py
+REM Archive with maximum zip compression
+7z a -tzip -mx9 -y ..\ESMB-win64-pyinstaller.zip .\dist\ESMB
+REM Cleanup
+RD /S /Q dist
 
-C:\Python37-x64\Scripts\pyinstaller -F -y -w -i icon.ico --hidden-import ttkthemes ESMB.py
-cp dist\ESMB ESMB-win64-pyinstaller.exe
-rd /S /Q dist
+REM Build a OneFile executable ("-F") with PyInstaller
+pyinstaller -F --noconfirm --noconsole --icon ..\icon.ico --hidden-import ttkthemes .\ESMB.py
+COPY .\dist\ESMB.exe ..\ESMB-win64-pyinstaller.exe
+REM Cleanup
+RD /S /Q dist
+
+REM Return to top level, just to be sure
+POPD

--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -1,19 +1,11 @@
 REM Add our desired Python installation the *beginning* of the PATH, so the "python" command refers to this executable.
+REM It HAS to be 3.7+, otherwise PyInstaller binaries will have import errors.
 REM Also add its "Scripts" folder, which will contain the PyInstaller executable once installed.
 set PATH=C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%
 
 REM Setup required Packages
-python -m pip install nuitka PyInstaller
+python -m pip install nuitka
 python -m pip install -r requirements.txt
-
-REM Nuitka Compilation
-REM The two plugin-related arguments are responsible for copying all required tkinter- and ttkthemes-files to the final distribution folder
-REM python -m nuitka --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=.\appveyor\ttkthemes_nuitka_plugin.py --plugin-enable=tk-inter --windows-disable-console --windows-icon=.\icon.ico .\src\ESMB.py
-MOVE .\ESMB.dist .\ESMB
-REM Archive with maximum zip compression
-7z a -tzip -mx9 -y .\ESMB-win64-nuitka.zip .\ESMB\
-REM Cleanup
-RD /S /Q ESMB
 
 REM Build a directory distribution ("-D") with PyInstaller
 REM We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,13 +1,13 @@
 sudo apt-get update && sudo apt-get -y install python3-pip python3-tk
-python3 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
+python3.7 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
 
 # Setup required python packages
-pip3 install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+pip3 install PyInstaller
 pip3 install -r requirements.txt
 
 # Build a directory distribution ("-D") with PyInstaller
 # We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
-pyinstaller -D --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+python3.7 -m PyInstaller -D --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
 # Archive with maximum zip compression
 env GZIP=-9 tar -czf ./ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
 # Cleanup
@@ -15,7 +15,7 @@ rm -rf dist/
 
 # Build a OneFile executable ("-F") with PyInstaller
 # We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
-pyinstaller -F --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+python3.7 -m PyInstaller -F --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
 cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
 # Cleanup
 rm -rf dist/

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,5 +1,6 @@
+# Install pip, python3-tk (tkinter package), python3.7 and python3.7-dev (to have libraries available)
+# Python HAS to be version 3.7+, otherwise PyInstaller binaries will have import errors for some reason
 sudo apt-get update && sudo apt-get -y install python3-pip python3-tk python3.7 python3.7-dev
-python3.7 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
 
 # Setup required python packages
 python3.7 -m pip install PyInstaller

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,4 +1,4 @@
-sudo apt-get update && sudo apt-get -y install python3-pip python3-tk
+sudo apt-get update && sudo apt-get -y install python3-pip python3-tk python3.7 python3.7-dev
 python3.7 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
 
 # Setup required python packages

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -1,24 +1,21 @@
-# Setup
-# chrpath can be required for nuitka's scons command, to adjust shared library paths
-sudo apt-get update && sudo apt-get -y install python3-pip python3-tk chrpath
-pip3 install nuitka #PyInstaller
+sudo apt-get update && sudo apt-get -y install python3-pip python3-tk
+python3 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
+
+# Setup required python packages
+pip3 install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 pip3 install -r requirements.txt
 
-# move into the folder containing ESMB.py
-#cd src
+# Build a directory distribution ("-D") with PyInstaller
+# We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
+pyinstaller -D --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+# Archive with maximum zip compression
+env GZIP=-9 tar -czf ./ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
+# Cleanup
+rm -rf dist/
 
-# Nuitka Compilation
-python3 -m nuitka --include-package=src --follow-imports --assume-yes-for-downloads --standalone --show-progress --show-scons --user-plugin=./appveyor/ttkthemes_nuitka_plugin.py src/ESMB.py
-ls
-mv ESMB.dist ESMB
-tar -czvf ESMB-ubuntu-amd64-nuitka.tar.gz ESMB/
-rm -rf ESMB
-
-# PyInstaller
-#python3 -m pyinstaller -D -y -w --hidden-import ttkthemes ESMB.py
-#tar -czvf ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
-#rm -rf dist
-
-#python3 -m pyinstaller -F -y -w --hidden-import ttkthemes ESMB.py
-#cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
-#rm -rf dist
+# Build a OneFile executable ("-F") with PyInstaller
+# We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
+pyinstaller -F --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
+# Cleanup
+rm -rf dist/

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -2,8 +2,8 @@ sudo apt-get update && sudo apt-get -y install python3-pip python3-tk python3.7 
 python3.7 --version # Make sure we are using the right version - it HAS to be 3.7+, otherwise PyInstaller binaries will have import errors
 
 # Setup required python packages
-pip3 install PyInstaller
-pip3 install -r requirements.txt
+python3.7 -m pip install PyInstaller
+python3.7 -m pip install -r requirements.txt
 
 # Build a directory distribution ("-D") with PyInstaller
 # We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it

--- a/src/ESMB.py
+++ b/src/ESMB.py
@@ -21,7 +21,7 @@ Endless Sky Github: https://github.com/endless-sky/endless-sky
 import sys
 import logging
 
-from model import Mission
+from src.model import Mission
 from src.gui.GUI import GUI
 import src.utils as utils
 import src.config as config

--- a/src/utils/loadtooltips.py
+++ b/src/utils/loadtooltips.py
@@ -19,6 +19,12 @@ import sys
 def load_tooltips():
     logging.debug("\tLoading tooltips...")
     file_path = os.path.join(sys.path[0], "data", "tooltips.json")
+
+    # When packaged with PyInstaller, all code is placed in a base_library.zip,
+    # while the data files are placed next to this zip.
+    if not os.path.exists(file_path):
+        file_path = os.path.join(sys.path[0], "..", "data", "tooltips.json")
+
     with open(file_path) as data_file:
         logging.debug("\tTooltips JSON file opened...")
         data = json.load(data_file)

--- a/src/utils/loadtooltips.py
+++ b/src/utils/loadtooltips.py
@@ -23,7 +23,7 @@ def load_tooltips():
     # When packaged with PyInstaller, all code is placed in a base_library.zip,
     # while the data files are placed next to this zip.
     if not os.path.exists(file_path):
-        file_path = os.path.join(sys.path[0], "..", "data", "tooltips.json")
+        file_path = os.path.normpath(os.path.join(sys.path[0], "..", "data", "tooltips.json"))
 
     with open(file_path) as data_file:
         logging.debug("\tTooltips JSON file opened...")


### PR DESCRIPTION
There have been some pretty big changes to the code structure, which the current build scripts are unable to deal with.

This PR tracks my progress in fixing these scripts. As of now, Windows builds using PyInstaller are working: https://ci.appveyor.com/api/buildjobs/m499b4kmpvwvo62h/artifacts/ESMB-win64-pyinstaller.exe

---

*5 hours later*
All done! With this PR,

- Nuitka binaries are gone because I couldn't get them to work.
- Binaries are built *exclusively* with Python3.7, to avoid some nasty import errors I've had with 3.6.
- Thus, you are discouraged to use [these](https://github.com/shitwolfymakes/Endless-Sky-Mission-Builder/pull/17/files#diff-54928cd85e1e7b15245bcc0d5a27fa15) kinds of imports - don't ask me what's different about them but changing this diff back will break the binaries.
- With Nuitka gone, build times have dropped to ~3min total.
- The build scripts are *much* more documented.
- When loading files included in the repo (prime example, the `src/data` directory), one has to respect an [extra case](https://github.com/shitwolfymakes/Endless-Sky-Mission-Builder/pull/17/files#diff-a7cb0246c05c871723422529f9fc6298) for PyInstaller Binaries, which store the code in `base_library.zip` (that's `sys.path[0]`), but the data files one level above the code, next to the zip.
- When loading files from directories not yet added to the binary (see the PyInstaller invocation in the build script), one has to add them to the command.

Since we've seen just how "stable" these builds are, I'd recommend changing the configuration so that a build is triggered on every commit on every branch (including PRs), and manually publishing them later. That way, errors can be detected before drafting a release.