### PR TITLE
adding parent path of ESMB.py to Pythonpath, s. #23

### DIFF
--- a/appveyor/build.bat
+++ b/appveyor/build.bat
@@ -9,14 +9,14 @@ python -m pip install -r requirements.txt
 
 REM Build a directory distribution ("-D") with PyInstaller
 REM We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
-pyinstaller -D --noconfirm --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
+pyinstaller -D --noconfirm --path .\src --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
 REM Archive with maximum zip compression
 7z a -tzip -mx9 -y .\ESMB-win64-pyinstaller.zip .\dist\ESMB
 REM Cleanup
 RD /S /Q dist
 
 REM Build a OneFile executable ("-F") with PyInstaller
-pyinstaller -F --noconfirm --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
+pyinstaller -F --noconfirm --path .\src --noconsole --icon .\icon.ico --hidden-import ttkthemes --add-data ".\src\data;data" .\src\ESMB.py
 COPY .\dist\ESMB.exe .\ESMB-win64-pyinstaller.exe
 REM Cleanup
 RD /S /Q dist

--- a/appveyor/build.sh
+++ b/appveyor/build.sh
@@ -8,7 +8,7 @@ python3.7 -m pip install -r requirements.txt
 
 # Build a directory distribution ("-D") with PyInstaller
 # We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
-python3.7 -m PyInstaller -D --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+python3.7 -m PyInstaller -D --noconfirm --path src --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
 # Archive with maximum zip compression
 env GZIP=-9 tar -czf ./ESMB-ubuntu-amd64-pyinstaller.tar.gz dist/ESMB/
 # Cleanup
@@ -16,7 +16,7 @@ rm -rf dist/
 
 # Build a OneFile executable ("-F") with PyInstaller
 # We have to add the data folder here since it won't be added automatically. See utils/loadtooltips.py for an example of how to access it
-python3.7 -m PyInstaller -F --noconfirm --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
+python3.7 -m PyInstaller -F --noconfirm --path src --hidden-import ttkthemes --add-data "src/data:data" src/ESMB.py
 cp dist/ESMB ESMB-ubuntu-amd64-pyinstaller
 # Cleanup
 rm -rf dist/

--- a/src/ESMB.py
+++ b/src/ESMB.py
@@ -22,8 +22,6 @@ import sys
 import logging
 import os
 
-#sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
-
 from model import Mission
 from gui.GUI import GUI
 import utils as utils

--- a/src/ESMB.py
+++ b/src/ESMB.py
@@ -22,13 +22,13 @@ import sys
 import logging
 import os
 
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+#sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
-from src.model import Mission
-from src.gui.GUI import GUI
-import src.utils as utils
-import src.config as config
-import src.singletons as singletons
+from model import Mission
+from gui.GUI import GUI
+import utils as utils
+import config as config
+import singletons as singletons
 
 
 class ESMB:

--- a/src/ESMB.py
+++ b/src/ESMB.py
@@ -20,6 +20,9 @@ Endless Sky Github: https://github.com/endless-sky/endless-sky
 """
 import sys
 import logging
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
 
 from src.model import Mission
 from src.gui.GUI import GUI

--- a/src/gui/GUI.py
+++ b/src/gui/GUI.py
@@ -13,8 +13,11 @@ import logging
 from tkinter import ttk
 from ttkthemes import ThemedTk
 
-import src.gui.editor as editor
-import src.config as config
+#import src.gui.editor as editor
+#import src.config as config
+
+import gui.editor as editor
+import config
 
 
 class GUI:

--- a/src/gui/GUI.py
+++ b/src/gui/GUI.py
@@ -13,9 +13,6 @@ import logging
 from tkinter import ttk
 from ttkthemes import ThemedTk
 
-#import src.gui.editor as editor
-#import src.config as config
-
 import gui.editor as editor
 import config
 

--- a/src/gui/editor/ItemTextPane.py
+++ b/src/gui/editor/ItemTextPane.py
@@ -13,9 +13,8 @@ import logging
 from tkinter import *
 from tkinter import ttk
 
-import src.config as config
-from src.gui.editor import GUIPane
-
+import config as config
+from gui.editor import GUIPane
 
 class ItemTextPane(ttk.Frame, GUIPane):
     #TODO: add vertical and horizontal scrollbars

--- a/src/gui/editor/MissionEditorPane.py
+++ b/src/gui/editor/MissionEditorPane.py
@@ -12,10 +12,9 @@
 import logging
 from tkinter import ttk
 
-import src.config as config
-import src.widgets as widgets
-from src.gui.editor import GUIPane
-
+import config
+import widgets
+from gui.editor import GUIPane
 
 class MissionEditorPane(widgets.ScrollingFrame, GUIPane):
     def __init__(self, parent):

--- a/src/gui/editor/OptionPane.py
+++ b/src/gui/editor/OptionPane.py
@@ -13,9 +13,9 @@ import logging
 from functools import partial
 from tkinter import ttk
 
-import src.config as config
-import src.utils as utils
-from src.gui.editor import GUIPane
+import config
+import utils
+from gui.editor import GUIPane
 
 
 class OptionPane(ttk.Frame, GUIPane):

--- a/src/model/Mission.py
+++ b/src/model/Mission.py
@@ -12,9 +12,10 @@
 
 import logging
 
-from src.model.model_data_parsers import MissionParser
+from model.model_data_parsers import MissionParser
 
-import src.model as model
+import model
+
 
 
 class Mission(model.FileItem):

--- a/src/model/MissionCompiler.py
+++ b/src/model/MissionCompiler.py
@@ -12,7 +12,7 @@
 
 import logging
 
-from src import config
+import config
 
 
 class MissionCompiler:

--- a/src/model/MissionComponents.py
+++ b/src/model/MissionComponents.py
@@ -14,8 +14,7 @@ This file contains the classes defining the components of a mission
 
 import logging
 
-import src.model.components as components
-
+import model.components as components
 
 class MissionComponents:
     """This class keeps instances of each different component in one place, for easy access"""

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -13,4 +13,4 @@ from .Mission import Mission
 from .MissionCompiler import MissionCompiler
 from .MissionComponents import MissionComponents
 
-import src.model.components
+import model.components

--- a/src/model/components/Trigger.py
+++ b/src/model/components/Trigger.py
@@ -12,9 +12,8 @@
 
 import logging
 
-from src.model.components.TriggerCondition import TriggerCondition
-from src.model.components.Log import Log
-
+from model.components.TriggerCondition import TriggerCondition
+from model.components.Log import Log
 
 class Trigger:
     #TODO: Implement this - ~80% Complete

--- a/src/model/file_data_parsers/FileMissionItemParser.py
+++ b/src/model/file_data_parsers/FileMissionItemParser.py
@@ -13,9 +13,9 @@ import logging
 import re
 import shlex
 
-from src import config
-from src.model import Mission
-from src.model.components.conversations import Conversation
+import config
+from model import Mission
+from model.components.conversations import Conversation
 
 
 class FileMissionItemParser:

--- a/src/model/file_data_parsers/MissionFileParser.py
+++ b/src/model/file_data_parsers/MissionFileParser.py
@@ -14,7 +14,7 @@
 import re
 import logging
 
-from src.model.file_data_parsers.FileMissionItemParser import FileMissionItemParser
+from model.file_data_parsers.FileMissionItemParser import FileMissionItemParser
 
 
 class MissionFileParser:

--- a/src/model/model_data_parsers/MissionParser.py
+++ b/src/model/model_data_parsers/MissionParser.py
@@ -12,7 +12,7 @@
 
 import logging
 
-from src.model.model_data_parsers.TriggerParser import TriggerParser
+from model.model_data_parsers.TriggerParser import TriggerParser
 
 
 class MissionParser:

--- a/src/utils/compilemission.py
+++ b/src/utils/compilemission.py
@@ -9,8 +9,8 @@
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
 """
-from src import config
-from src.model import MissionCompiler
+import config
+from model import MissionCompiler
 
 
 def compile_mission():

--- a/src/utils/newmission.py
+++ b/src/utils/newmission.py
@@ -12,7 +12,7 @@
 
 import logging
 
-from src.widgets.NewMissionPopup import NewMissionPopup
+from widgets.NewMissionPopup import NewMissionPopup
 
 
 def new_mission():

--- a/src/utils/openfile.py
+++ b/src/utils/openfile.py
@@ -13,8 +13,8 @@
 import logging
 from tkinter import filedialog
 
-from src import config
-from src.model.file_data_parsers import MissionFileParser
+import config
+from model.file_data_parsers import MissionFileParser
 
 
 def open_file():

--- a/src/utils/savefile.py
+++ b/src/utils/savefile.py
@@ -13,9 +13,8 @@
 import logging
 from tkinter import filedialog
 
-from src import config
-from src.utils.compilemission import compile_mission
-
+import config
+from utils.compilemission import compile_mission
 
 def save_file():
     """This method saves the data to a mission file"""

--- a/src/widgets/AggregatedLogFrame.py
+++ b/src/widgets/AggregatedLogFrame.py
@@ -15,7 +15,7 @@ from functools import partial
 from tkinter import *
 from tkinter import ttk
 
-import src.widgets as widgets
+import widgets
 
 
 class AggregatedLogFrame(ttk.Frame):

--- a/src/widgets/AggregatedTriggerConditionFrame.py
+++ b/src/widgets/AggregatedTriggerConditionFrame.py
@@ -15,7 +15,7 @@ from functools import partial
 from tkinter import *
 from tkinter import ttk
 
-from src import widgets as widgets
+import widgets
 
 
 class AggregatedTriggerConditionFrame(ttk.Frame):

--- a/src/widgets/AggregatedTriggerFrame.py
+++ b/src/widgets/AggregatedTriggerFrame.py
@@ -15,9 +15,8 @@ from functools import partial
 from tkinter import *
 from tkinter import ttk
 
-import src.widgets as widgets
-from src import config
-
+import widgets
+import config
 
 class AggregatedTriggerFrame(ttk.Frame):
     """

--- a/src/widgets/ComboComponentFrame.py
+++ b/src/widgets/ComboComponentFrame.py
@@ -14,8 +14,7 @@ import logging
 from functools import partial
 from tkinter import ttk, BooleanVar
 
-import src.widgets as widgets
-
+import widgets
 
 class ComboComponentFrame(ttk.Frame):
     """This class extends ttk.Frame to create a custom GUI widget"""

--- a/src/widgets/ComponentMandOptFrame.py
+++ b/src/widgets/ComponentMandOptFrame.py
@@ -16,7 +16,7 @@ from functools import partial
 from tkinter import *
 from tkinter import ttk
 
-import src.widgets as widgets
+import widgets
 
 
 class ComponentMandOptFrame(ttk.Frame):

--- a/src/widgets/LogWindow.py
+++ b/src/widgets/LogWindow.py
@@ -14,7 +14,7 @@ import logging
 from tkinter import *
 from tkinter import ttk
 
-import src.widgets as widgets
+import widgets
 
 
 class LogWindow(Toplevel):

--- a/src/widgets/NewMissionPopup.py
+++ b/src/widgets/NewMissionPopup.py
@@ -14,9 +14,8 @@ import logging
 from tkinter import ttk
 from ttkthemes import ThemedTk
 
-from src import config
-from src.model import Mission
-
+import config
+from model import Mission
 
 class NewMissionPopup(object):
     """This class creates a custom pop-up window for use when creating a new Mission object"""

--- a/src/widgets/ScrollingFrame.py
+++ b/src/widgets/ScrollingFrame.py
@@ -13,7 +13,7 @@
 from tkinter import *
 from tkinter import ttk
 
-import src.config as config
+import config
 
 
 class ScrollingFrame(ttk.Frame):

--- a/src/widgets/TooltipLabel.py
+++ b/src/widgets/TooltipLabel.py
@@ -13,8 +13,8 @@
 from tkinter import *
 from tkinter import ttk
 
-import src.config as config
-from src.widgets.Tooltip import add_tooltip
+import config
+from widgets.Tooltip import add_tooltip
 
 
 class TooltipLabel(ttk.Label):

--- a/src/widgets/TriggerConditionWindow.py
+++ b/src/widgets/TriggerConditionWindow.py
@@ -16,7 +16,7 @@ from tkinter import ttk
 
 from ttkthemes import ThemedTk
 
-import src.widgets as widgets
+import widgets
 
 
 class TriggerConditionWindow(Toplevel):

--- a/src/widgets/TriggerFrame.py
+++ b/src/widgets/TriggerFrame.py
@@ -13,7 +13,7 @@
 from functools import partial
 from tkinter import ttk
 
-from src import config
+import config
 
 
 class TriggerFrame(ttk.Frame):

--- a/src/widgets/TriggerWindow.py
+++ b/src/widgets/TriggerWindow.py
@@ -14,8 +14,8 @@ import logging
 from tkinter import *
 from tkinter import ttk
 
-import src.widgets as widgets
-from src import config
+import widgets
+import config
 
 
 class TriggerWindow(Toplevel):


### PR DESCRIPTION
## Summary
[MINOR]: The parent path to the ESMB.py file is now added to the Pythonpath.


-----------------------
**Bugfix:** This PR addresses issue #23

## Fix Details
The parent path to the ESMB.py file is now added to the Pythonpath. From there the path src will be available to let statements like `from src.model import Mission` always work, no matter from where you are when starting ESMB.py.

Please note that there is still an issue with the editor import on other than the supported environments, which is not a path issue. As it obviously works with Ubuntu and Python 3.7 (as opposed to my configuration Fedora 33 with Python 3.9). Anyway the issue was the subject of #20.

@MCOfficer : change the target branch or repo as you think fits.


